### PR TITLE
Refactor project settings and engine paths for improved asset management

### DIFF
--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -40,7 +40,7 @@ Engine::~Engine() {
 
 void Engine::run() {
     std::cout << "Welcome to Impgine!\n";
-    loadScene(project.getFullPath(project.startupScene));
+    loadScene(project.getFullPath(project.lastScene));
     std::cout << "Project: " << project.projectName << " loaded" << std::endl;
     std::cout << "ECSRegistry currently has " << ECSRegistry::getRegistry().getEntities().size() << " entities" << std::endl;
 
@@ -80,7 +80,7 @@ void Engine::initVulkan() {
     resourceManager = new ResourceManager(device, physicalDevice);
 
     // Configure fallback texture path
-    resourceManager->setFallbackTexturePath(project.getFullPath("engine/textures/texture.jpg"));
+    resourceManager->setFallbackTexturePath(project.getEnginePath() + "/Textures/texture.jpg");
 
     // Set global resource manager context
     setResourceManagerGlobals(commandPool, graphicsQueue);
@@ -302,20 +302,20 @@ void Engine::loadScene(const std::string& scenePath) {
     pipelineConfig.pipelineLayout = pipelineLayout;
     pipelineConfig.multisampleInfo.rasterizationSamples = msaaSamples;
 
-    std::string vertShader = project.getFullPath(project.shadersPath + "/vert.spv");
-    std::string fragShader = project.getFullPath(project.shadersPath + "/frag.spv");
+    std::string vertShader = project.getShadersPath() + "/vert.spv";
+    std::string fragShader = project.getShadersPath() + "/frag.spv";
     pipeline = std::make_unique<Pipeline>(device, vertShader, fragShader, pipelineConfig);
 
     createCommandBuffers(device, commandPool, SwapChain::MAX_FRAMES_IN_FLIGHT, commandBuffers);
 
     // Initialize UI renderer and a default window
     {
-        std::string uiVert = project.getFullPath(project.shadersPath + "/ui.vert.spv");
-        std::string uiFrag = project.getFullPath(project.shadersPath + "/ui.frag.spv");
+        std::string uiVert = project.getShadersPath() + "/ui.vert.spv";
+        std::string uiFrag = project.getShadersPath() + "/ui.frag.spv";
         uiRenderer = std::make_unique<UIRenderer>(device, physicalDevice, renderPass, pipelineLayout, commandPool, graphicsQueue, *swapChain, msaaSamples, uiVert, uiFrag);
 
         // Load Arial font and create descriptor sets
-        std::string fontPath = project.getFullPath("engine/ttf/arial.ttf");
+        std::string fontPath = project.getEnginePath() + "/TTF/arial.ttf";
         uiRenderer->getTextRenderer()->loadFont(fontPath, 48);
 
         // Create descriptor sets after font texture is loaded
@@ -402,11 +402,11 @@ void Engine::drawFrame() {
 }
 
 void Engine::recreateSwapChain() {
-    std::string vertShader = project.getFullPath(project.shadersPath + "/vert.spv");
-    std::string fragShader = project.getFullPath(project.shadersPath + "/frag.spv");
-    std::string uiVert = project.getFullPath(project.shadersPath + "/ui.vert.spv");
-    std::string uiFrag = project.getFullPath(project.shadersPath + "/ui.frag.spv");
-    std::string fontPath = project.getFullPath("engine/ttf/arial.ttf");
+    std::string vertShader = project.getShadersPath() + "/vert.spv";
+    std::string fragShader = project.getShadersPath() + "/frag.spv";
+    std::string uiVert = project.getShadersPath() + "/ui.vert.spv";
+    std::string uiFrag = project.getShadersPath() + "/ui.frag.spv";
+    std::string fontPath = project.getEnginePath() + "/TTF/arial.ttf";
 
     // Release ownership from unique_ptrs so impgine::recreateSwapChain can delete them
     SwapChain* swapChainPtr = swapChain.release();

--- a/engine/project.hpp
+++ b/engine/project.hpp
@@ -10,8 +10,6 @@ namespace impgine {
 struct ProjectSettings {
     std::string projectPath;
     std::string projectName;
-    std::string version;
-    std::string engineVersion;
 
     // Window settings
     int windowWidth = 800;
@@ -22,19 +20,17 @@ struct ProjectSettings {
     int msaaSamples = 4;
     bool vsync = true;
 
-    // Asset paths (relative to project folder)
-    std::string scenesPath = "assets/scenes";
-    std::string modelsPath = "assets/models";
-    std::string texturesPath = "assets/textures";
-    std::string shadersPath = "engine/shaders";
-
-    // Startup
-    std::string startupScene = "assets/scenes/scene.imp";
+    // Last opened scene
+    std::string lastScene = "Assets/Scenes/scene.imp";
 
     // Helper to get full path
     std::string getFullPath(const std::string& relativePath) const {
         return projectPath + "/" + relativePath;
     }
+
+    // Engine paths (standardized by engine)
+    std::string getEnginePath() const { return projectPath + "/Engine"; }
+    std::string getShadersPath() const { return projectPath + "/Engine/Shaders"; }
 };
 
 class Project {
@@ -46,6 +42,14 @@ public:
         size_t lastSlash = projectFilePath.find_last_of("/\\");
         if (lastSlash != std::string::npos) {
             settings.projectPath = projectFilePath.substr(0, lastSlash);
+        }
+
+        // Extract project name from folder name
+        size_t secondLastSlash = settings.projectPath.find_last_of("/\\");
+        if (secondLastSlash != std::string::npos) {
+            settings.projectName = settings.projectPath.substr(secondLastSlash + 1);
+        } else {
+            settings.projectName = settings.projectPath;
         }
 
         std::ifstream file(projectFilePath);
@@ -83,12 +87,7 @@ public:
             std::string value = trim(line.substr(sep + 1));
 
             // Parse based on current section
-            if (currentSection == "project") {
-                if (key == "name") settings.projectName = value;
-                else if (key == "version") settings.version = value;
-                else if (key == "engine_version") settings.engineVersion = value;
-            }
-            else if (currentSection == "window") {
+            if (currentSection == "window") {
                 if (key == "width") settings.windowWidth = std::stoi(value);
                 else if (key == "height") settings.windowHeight = std::stoi(value);
                 else if (key == "title") settings.windowTitle = value;
@@ -97,14 +96,8 @@ public:
                 if (key == "msaa_samples") settings.msaaSamples = std::stoi(value);
                 else if (key == "vsync") settings.vsync = (value == "true");
             }
-            else if (currentSection == "assets") {
-                if (key == "scenes_path") settings.scenesPath = value;
-                else if (key == "models_path") settings.modelsPath = value;
-                else if (key == "textures_path") settings.texturesPath = value;
-                else if (key == "shaders_path") settings.shadersPath = value;
-            }
-            else if (currentSection == "startup") {
-                if (key == "scene") settings.startupScene = value;
+            else if (currentSection == "editor") {
+                if (key == "last_scene") settings.lastScene = value;
             }
         }
 

--- a/engine/shaders/shader_compiler.cpp
+++ b/engine/shaders/shader_compiler.cpp
@@ -19,7 +19,7 @@ bool ShaderCompiler::compileShader(const std::string& sourcePath, const std::str
 
 void ShaderCompiler::compileAllShaders(const ProjectSettings& project) {
     std::cout << "Compiling shaders..." << std::endl;
-    std::string shaderPath = project.getFullPath(project.shadersPath);
+    std::string shaderPath = project.getShadersPath();
     std::string vertSource = shaderPath + "/shader.vert";
     std::string fragSource = shaderPath + "/shader.frag";
     std::string vertOutput = shaderPath + "/vert.spv";

--- a/example/project.imp
+++ b/example/project.imp
@@ -1,25 +1,13 @@
 %IMP Project 1.0
 ---
-project:
-  name: Example Project
-  version: 1.0.0
-  engine_version: 1.0.0
+window:
+  width: 800
+  height: 600
+  title: Impgine - Example Project
 
-settings:
-  window:
-    width: 800
-    height: 600
-    title: Impgine - Example Project
+rendering:
+  msaa_samples: 4
+  vsync: true
 
-  rendering:
-    msaa_samples: 4
-    vsync: true
-
-assets:
-  scenes_path: assets/scenes
-  models_path: assets/models
-  textures_path: assets/textures
-  shaders_path: engine/shaders
-
-startup:
-  scene: assets/scenes/scene.imp
+editor:
+  last_scene: Assets/Scenes/scene.imp


### PR DESCRIPTION
- Updated Engine class to utilize new methods for retrieving shader and engine paths, enhancing code readability and maintainability.
- Changed the last scene reference in ProjectSettings to reflect the last opened scene instead of the startup scene.
- Removed deprecated versioning fields from ProjectSettings for a cleaner configuration structure.
- Adjusted shader compilation logic to use the updated path methods, ensuring consistency across the codebase.